### PR TITLE
Rename application service endpoints

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -13,14 +13,12 @@ from aica_api.client import AICA
 aica = AICA()
 
 aica.set_application('my_application.yaml')
-aica.init_application()
 aica.start_application()
 
 aica.load_component('my_component')
 aica.unload_component('my_component')
 
 aica.stop_application()
-aica.reset_application()
 ```
 
 To check the status of component predicates and conditions, the following blocking methods can be employed:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aica_api"
-version = "0.0.2"
+version = "0.0.3"
 authors = [
   { name="Enrico Eberhard", email="enrico@aica.tech" },
 ]

--- a/python/src/aica_api/client.py
+++ b/python/src/aica_api/client.py
@@ -110,11 +110,12 @@ class AICA:
         """
         return requests.post(self._endpoint('load_hardware'), json={"interface_name": interface_name})
 
-    def reset_application(self) -> requests.Response:
+    def pause_application(self) -> requests.Response:
         """
-        Reset the current application, removing all components and hardware interfaces.
+        Pause the current application. This prevents any events from being triggered or handled, but
+        does not pause the periodic execution of active components.
         """
-        return requests.post(self._endpoint('reset_application'))
+        return requests.post(self._endpoint('pause_application'))
 
     def set_application(self, payload: str) -> requests.Response:
         """
@@ -133,7 +134,7 @@ class AICA:
 
     def stop_application(self) -> requests.Response:
         """
-        Stop the AICA application engine.
+        Stop and reset the AICA application engine, removing all components and hardware interfaces.
         """
         return requests.post(self._endpoint('stop_application'))
 


### PR DESCRIPTION
Upcoming changes to the application API endpoints are intended to increase the clarity of behaviours. The following endpoints are affected: 

- `stop_application` has been renamed to `pause_application`
- `reset_application` has been renamed to `stop_application`