### PR TITLE
Extend application schema with conditions

### DIFF
--- a/applications/schema/schema/application.schema.json
+++ b/applications/schema/schema/application.schema.json
@@ -33,6 +33,9 @@
     "hardware_interfaces": {
       "$ref": "hardware_interfaces.schema.json"
     },
+    "conditions": {
+      "$ref": "conditions.schema.json"
+    },
     "components": {
       "$ref": "components.schema.json"
     }

--- a/applications/schema/schema/components.schema.json
+++ b/applications/schema/schema/components.schema.json
@@ -74,18 +74,18 @@
           }
         },
         "events": {
-          "title": "Predicate events",
+          "title": "Predicate Events",
           "description": "Component predicates that trigger events",
           "type": "object",
           "additionalProperties": false,
           "properties": {
             "on_load": {
-              "title": "On load",
+              "title": "On Load",
               "description": "An internal predicate that triggers events when the component is loaded",
               "$ref": "events.schema.json"
             },
             "on_unload": {
-              "title": "On unload",
+              "title": "On Unload",
               "description": "An internal predicate that triggers events when the component is unloaded",
               "$ref": "events.schema.json"
             },
@@ -95,34 +95,34 @@
               "$ref": "events.schema.json"
             },
             "is_inactive": {
-              "title": "Is inactive (lifecycle)",
+              "title": "Is Inactive (lifecycle)",
               "description": "A lifecycle predicate that triggers events when the component enters the inactive state",
               "$ref": "events.schema.json"
             },
             "is_active": {
-              "title": "Is active (lifecycle)",
+              "title": "Is Active (lifecycle)",
               "description": "A lifecycle predicate that triggers events when the component enters the active state",
               "$ref": "events.schema.json"
             },
             "is_finalized": {
-              "title": "Is finalized (lifecycle)",
+              "title": "Is Finalized (lifecycle)",
               "description": "A lifecycle predicate that triggers events when the component enters the finalized state",
               "$ref": "events.schema.json"
             },
             "is_finished": {
-              "title": "Is finished",
+              "title": "Is Finished",
               "description": "A standard predicate that triggers events when the component finishes executing a post-construction function",
               "$ref": "events.schema.json"
             },
             "in_error_state": {
-              "title": "In error state",
+              "title": "In Error State",
               "description": "A predicate that triggers events when the component encounters an error",
               "$ref": "events.schema.json"
             }
           },
           "patternProperties": {
             "^[a-zA-Z][a-zA-Z0-9_]*[a-zA-Z0-9]$": {
-              "title": "Custom predicate",
+              "title": "Custom Predicate",
               "description": "A component-specific predicate",
               "$ref": "events.schema.json"
             }

--- a/applications/schema/schema/conditions.schema.json
+++ b/applications/schema/schema/conditions.schema.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Conditions",
+  "description": "A description of logical conditions used to trigger events in the application",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "(^[a-zA-Z][a-zA-Z0-9_]*[a-zA-Z0-9]$)|(^[a-zA-Z]$)": {
+      "title": "Condition Name",
+      "description": "The name of the condition",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "events": {
+          "title": "Conditional Events",
+          "description": "Events triggered by the condition",
+          "$ref": "events.schema.json"
+        }
+      },
+      "required": [
+        "events"
+      ],
+      "oneOf": [
+        {
+          "$ref": "#/$defs/condition_object"
+        },
+        {
+          "$ref": "#/$defs/predicate_object"
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "condition_object": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "all": {
+          "title": "All",
+          "description": "True only when every listed item is true",
+          "$ref": "#/$defs/condition_array"
+        },
+        "any": {
+          "title": "Any",
+          "description": "True if at least one of the listed items is true",
+          "$ref": "#/$defs/condition_array"
+        },
+        "one_of": {
+          "title": "One Of",
+          "description": "True only when exactly one of the listed items is true",
+          "$ref": "#/$defs/condition_array"
+        },
+        "not": {
+          "title": "Not",
+          "description": "True only when the sub-item is false",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/condition_object"
+            },
+            {
+              "$ref": "#/$defs/predicate_object"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "all"
+          ]
+        },
+        {
+          "required": [
+            "any"
+          ]
+        },
+        {
+          "required": [
+            "one_of"
+          ]
+        },
+        {
+          "required": [
+            "not"
+          ]
+        }
+      ]
+    },
+    "condition_array": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/$defs/condition_object"
+          },
+          {
+            "$ref": "#/$defs/predicate_object"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      }
+    },
+    "predicate_object": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "component": {
+          "$ref": "events/identifiers/component.schema.json"
+        },
+        "predicate": {
+          "title": "Predicate Name",
+          "description": "The name of a predicate associated with the component",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9_]*[a-zA-Z0-9]$"
+        }
+      },
+      "required": [
+        "component",
+        "predicate"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
To wrap up the schema, here are conditions. It was actually not as bad as I thought to incorporate the recursive logic. A quick summary:

Top-level must have `events` and either `condition_object` or `predicate_object` fields. The predicate object is just an associated component and predicate. The condition object has fields [all, any, one_of, not]. The first three refer to `condition_array` - that is, a list of items which must be either another condition object, predicate object, or bool (for hard-coded conditions). The `not` doesn't take an array of items, but instead just one of condition object, predicate object, or bool.


Here are some valid examples that are validated correctly:

```yaml
# valid conditions
conditions:
  test_single_predicate:
    component: foo
    predicate: foo
    events:
      load: foo
  test_single_not:
    not:
      component: foo
      predicate: foo
    events:
      load: foo
  test_nested_condition:
    not:
      all:
        - { component: foo, predicate: is_foo }
        - { component: test_component_01, predicate: is_foo }
        - any:
            - { component: test_component_02, predicate: is_foo }
            - { component: test_component_03, predicate: is_foo }
            - one_of:
                - { component: unregistered_component, predicate: is_foo }
                - false
                - true
    events:
      load: foo
```

Here are invalid conditions that are correctly identified
```yaml
# invalid conditions
conditions:
  test_no_events:
    component: none
    predicate: none
  test_no_condition:
    events:
      load: foo
  test_multiple_fields:
    all:
      - true
      - false
    any:
      - true
      - false
    events:
      load: foo
  test_invalid_subobject:
    all:
      - { not: a, valid: object }
    events:
      load: foo
  test_listed_not:
    not:
      - true
      - false
    events:
      load: foo
```

@buschbapti 