### PR TITLE
Extend component YAML schema with more abstractions

### DIFF
--- a/applications/schema/schema/components.schema.json
+++ b/applications/schema/schema/components.schema.json
@@ -23,6 +23,11 @@
             "fatal"
           ]
         },
+        "display_name": {
+          "title": "Component Display Name",
+          "description": "The human-readable name to display on the component",
+          "type": "string"
+        },
         "component": {
           "title": "Component Registration",
           "description": "The fully qualified class name used to register the component",
@@ -70,6 +75,32 @@
                   "string"
                 ]
               }
+            }
+          }
+        },
+        "inputs": {
+          "title": "Inputs",
+          "description": "Input signals of the component",
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "(^[a-zA-Z][a-zA-Z0-9_]*[a-zA-Z0-9]$)|(^[a-zA-Z]$)": {
+              "title": "Input topic",
+              "description": "The corresponding topic of the input signal",
+              "type": "string"
+            }
+          }
+        },
+        "outputs": {
+          "title": "Outputs",
+          "description": "Output signals of the component",
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "(^[a-zA-Z][a-zA-Z0-9_]*[a-zA-Z0-9]$)|(^[a-zA-Z]$)": {
+              "title": "Output topic",
+              "description": "The corresponding topic of the output signal",
+              "type": "string"
             }
           }
         },


### PR DESCRIPTION
* Add a display_name property that allows the component to have a nicer, human-readable name (i.e. one that doesn't need to be lower_snake_case)

* Add signals properties (inputs / outputs) that would replace occurences of `foo_topic` parameters

<!-- AICA Pull Request Template: 10 easy steps for a successful PR!
1. Give the PR a relevant and descriptive title
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
6. Add any supporting resources (screenshots, test results, etc)
7. Help the reviewer by suggestion the method and estimated time to review
8. If applicable, make a checklist of tasks that should be completed before merging
9. If applicable, mention related issues (blocked by / blocks)
10. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->
- #10 

<!-- Required: explain how the PR addresses the parent issue -->
This PR solves the issue by adding the suggested elements to the YAML schema. It is a non-breaking change as the new fields are just optional abstractions.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

## Related issues

No issue has been created yet, but as a follow-up action I would implement the signal abstraction in the state engine YAML parsing.