### PR TITLE
Support input collections in YAML schema

### DIFF
--- a/applications/schema/schema/components.schema.json
+++ b/applications/schema/schema/components.schema.json
@@ -104,6 +104,22 @@
             }
           }
         },
+        "input_collections": {
+          "title": "Input collections",
+          "description": "Collections of input signals of the component",
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "(^[a-zA-Z][a-zA-Z0-9_]*[a-zA-Z0-9]$)|(^[a-zA-Z]$)": {
+              "title": "Input topics",
+              "description": "The array of topics that are included in the signal collection",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "events": {
           "title": "Predicate Events",
           "description": "Component predicates that trigger events",


### PR DESCRIPTION
<!-- AICA Pull Request Template: 10 easy steps for a successful PR!
1. Give the PR a relevant and descriptive title
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
6. Add any supporting resources (screenshots, test results, etc)
7. Help the reviewer by suggestion the method and estimated time to review
8. If applicable, make a checklist of tasks that should be completed before merging
9. If applicable, mention related issues (blocked by / blocks)
10. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->
- #10

As a small followup to the issue and #11, I remembered that signal collections are also a thing we can eventually support. As with inputs / outputs, the idea is just to append `_topics` to the collection name and set the parameter.

Before:
```yaml
  recorder:
    component: base_components::data::filesystem::BinaryRecorder
    parameters:
      recording_directory: /tmp
      recordings_topics: [ force_controller/cartesian_state ]
```

After:
```yaml
  recorder:
    component: base_components::data::filesystem::BinaryRecorder
    parameters:
      recording_directory: /tmp
    input_collections:
      recordings: [ force_controller/cartesian_state ]
```

A slightly more complicated option would be to have the `inputs:` field allow either `string` or `string_array` data, then have the YAML parser convert it either to `_topic` or `_topics` parameter respectively. This would make input collections just inputs with array topics. But, I prefer to split them as I think it's more explicit that way, and also aligns with component description and front-end concepts for input collections.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 2 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->