### PR TITLE
Controller inheritance and internal parameters

### DIFF
--- a/schemas/component-descriptions/README.md
+++ b/schemas/component-descriptions/README.md
@@ -209,9 +209,14 @@ default state and must be set by the user for the component to function, the `de
 description should be set to `null`. This is distinct from a valid default empty parameter state, which can be
 expressed with the empty string `""`.
 
-If a parameter is dynamically reconfigurable, it implies that the parameter can be changed after the component
-is already configured to influence the run-time behaviour.
+If a parameter is dynamically reconfigurable, as described by the `dynamic` property, it implies that the parameter can
+be changed after the component is already configured to influence the run-time behaviour.
 This requires the component to either poll the parameter value while running or implement a parameter change callback.
+
+The `internal` property can be used to hide a parameter from public interfaces that use the component description by
+indicating that the parameter is intended for internal use only. The intended outcome is for the parameter to be hidden
+from auto-generated component visualizations or documentation at a high level.
+If the field is omitted from a description, the parameter is assumed to be public.
 
 ## Predicates
 

--- a/schemas/controller-descriptions/README.md
+++ b/schemas/controller-descriptions/README.md
@@ -10,6 +10,11 @@ Refer to the relevant documentation in the component descriptions folder for a s
 The `plugin` property is similar to the `registration` property of a component, and defines the unique name under
 which the controller plugin class is registered.
 
+### Inheritance
+
+The `inheritance` property is similar to components, but simplified in this schema to just reference the parent class
+by plugin name rather than allowing nested references.
+
 ### Control type
 
 The `control_type` property defines which joint command interface the controller will claim. If the control type is

--- a/schemas/controller-descriptions/schema/controller.schema.json
+++ b/schemas/controller-descriptions/schema/controller.schema.json
@@ -47,6 +47,13 @@
       ],
       "type": "string"
     },
+    "inherits": {
+      "description": "The parent class name of the controller plugin in case of inheritance.",
+      "examples": [
+        "modulo_controllers/ModuloControllerInterface"
+      ],
+      "type": "string"
+    },
     "control_type": {
       "description": "The control type of the controller",
       "examples": [

--- a/schemas/parameters/schema/parameter.schema.json
+++ b/schemas/parameters/schema/parameter.schema.json
@@ -52,6 +52,11 @@
     "dynamic": {
       "description": "Specify if this parameter can be dynamically reconfigured.",
       "type": "boolean"
+    },
+    "internal": {
+      "description": "Specify if this parameter is for internal use only and should be hidden from public users.",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": [


### PR DESCRIPTION
<!-- AICA Pull Request Template: 10 easy steps for a successful PR!
1. Give the PR a relevant and descriptive title
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
6. Add any supporting resources (screenshots, test results, etc)
7. Help the reviewer by suggestion the method and estimated time to review
8. If applicable, make a checklist of tasks that should be completed before merging
9. If applicable, mention related issues (blocked by / blocks)
10. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->
- https://github.com/aica-technology/modulo-controllers/issues/91

Following #20, I also wanted to have the ability to mark inheritance for controllers. However, many of the base parameters in the modulo controller interface are "optional" or only used internally. Derived controllers often will not need to set this, and in general the user-facing parameters should be reduced where possible. The new `internal` property for parameters allows us to mark this behavior and thereby hide some parameters from the user (unless they tick some box to show all parameters for example).

I did it in a separate step because I wanted to add a field to the parameters descriptions, but not introduce too many changes in a single PR.

Up to debate whether `internal` is a good name or something like `advanced` would be preferred.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->