### PR TITLE
Fix websocket client

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aica_api"
-version = "0.0.3"
+version = "0.0.4"
 authors = [
   { name="Enrico Eberhard", email="enrico@aica.tech" },
 ]

--- a/python/src/aica_api/client.py
+++ b/python/src/aica_api/client.py
@@ -45,7 +45,7 @@ class AICA:
         :param endpoint: The websocket endpoint
         :return: The constructed connection address
         """
-        return f'{self._ws_address}/v1/{endpoint}'
+        return f'{self._ws_address}/{endpoint}'
 
     def check(self) -> requests.Response:
         """
@@ -205,16 +205,16 @@ class AICA:
         :param timeout: Timeout duration in seconds. If set to None, block indefinitely
         :return: False if the connection times out before the predicate is true
         """
-        component = f'/{component}'
+        component = f'{component}'
 
         def check_predicate(data):
             try:
-                if data[component][predicate]:
+                if data[component]["predicates"][predicate]:
                     return True
             except KeyError:
                 return False
 
-        ws = WebsocketSyncClient(self._ws_endpoint('predicates'))
+        ws = WebsocketSyncClient(self._ws_endpoint('components'))
         return ws.read_until(check_predicate, timeout=timeout)
 
     def wait_for_condition(self, condition, timeout=None):


### PR DESCRIPTION
<!-- AICA Pull Request Template: 10 easy steps for a successful PR!
1. Give the PR a relevant and descriptive title
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
6. Add any supporting resources (screenshots, test results, etc)
7. Help the reviewer by suggestion the method and estimated time to review
8. If applicable, make a checklist of tasks that should be completed before merging
9. If applicable, mention related issues (blocked by / blocks)
10. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->
Small bug fix after #19, I didn't notice that the websocket endpoint was also changed to have `/v1`. This causes the websocket connection to fail.

Maybe it would actually be a good idea to put the websockets under the v1 namespace also, but for now the websockets are published directly on `/components`, `/conditions` and `/logs`. 

I also finally fixed up the `wait_for_predicate` function, since it was using the long-deprecated `/predicates` websocket which doesn't exist. The new functions were tested with a real application and working as intended.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 2 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->