### PR TITLE
feat(application schema): add support for setting controller parameters

### DIFF
--- a/schemas/applications/schema/events/set.schema.json
+++ b/schemas/applications/schema/events/set.schema.json
@@ -39,29 +39,13 @@
       }
     },
     "controller": {
-      "title": "Conntroller Name", 
+      "title": "Controller Name", 
       "description": "The name of a controller",
       "type": "string",
       "pattern": "(^[a-zA-Z][a-zA-Z0-9_]*[a-zA-Z0-9]$)|(^[a-zA-Z]$)"
     },
     "set_parameter_object": {
       "oneOf": [
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "parameter": {
-              "$ref": "#/$defs/parameter"
-            },
-            "value": {
-              "$ref": "#/$defs/value"
-            }
-          },
-          "required": [
-            "parameter",
-            "value"
-          ]
-        },
         {
           "type": "object",
           "additionalProperties": false,
@@ -78,8 +62,7 @@
           },
           "required": [
             "parameter",
-            "value",
-            "component"
+            "value"
           ]
         },
         {

--- a/schemas/applications/schema/events/set.schema.json
+++ b/schemas/applications/schema/events/set.schema.json
@@ -15,40 +15,97 @@
     }
   ],
   "$defs": {
+    "parameter": {
+      "title": "Parameter Name",
+      "description": "The name of a parameter to set",
+      "type": "string",
+      "pattern": "(^[a-zA-Z][a-zA-Z0-9_]*[a-zA-Z0-9]$)|(^[a-zA-Z]$)"
+    },
+    "value": {
+      "title": "Parameter Value",
+      "description": "The value of the parameter to set",
+      "type": [
+        "boolean",
+        "number",
+        "string",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "boolean",
+          "number",
+          "string"
+        ]
+      }
+    },
+    "controller": {
+      "title": "Conntroller Name", 
+      "description": "The name of a controller",
+      "type": "string",
+      "pattern": "(^[a-zA-Z][a-zA-Z0-9_]*[a-zA-Z0-9]$)|(^[a-zA-Z]$)"
+    },
     "set_parameter_object": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "parameter": {
-          "title": "Parameter Name",
-          "description": "The name of a parameter to set",
-          "type": "string",
-          "pattern": "(^[a-zA-Z][a-zA-Z0-9_]*[a-zA-Z0-9]$)|(^[a-zA-Z]$)"
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "parameter": {
+              "$ref": "#/$defs/parameter"
+            },
+            "value": {
+              "$ref": "#/$defs/value"
+            }
+          },
+          "required": [
+            "parameter",
+            "value"
+          ]
         },
-        "value": {
-          "title": "Parameter Value",
-          "description": "The value of the parameter to set",
-          "type": [
-            "boolean",
-            "number",
-            "string",
-            "array"
-          ],
-          "items": {
-            "type": [
-              "boolean",
-              "number",
-              "string"
-            ]
-          }
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "parameter": {
+              "$ref": "#/$defs/parameter"
+            },
+            "value": {
+              "$ref": "#/$defs/value"
+            },
+            "component": {
+              "$ref": "identifiers/component.schema.json"
+            }
+          },
+          "required": [
+            "parameter",
+            "value",
+            "component"
+          ]
         },
-        "component": {
-          "$ref": "identifiers/component.schema.json"
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "parameter": {
+              "$ref": "#/$defs/parameter"
+            },
+            "value": {
+              "$ref": "#/$defs/value"
+            },
+            "interface": {
+              "$ref": "identifiers/hardware.schema.json"
+            },
+            "controller": {
+              "$ref": "#/$defs/controller"
+            }
+          },
+          "required": [
+            "parameter",
+            "value",
+            "interface",
+            "controller"
+          ]
         }
-      },
-      "required": [
-        "parameter",
-        "value"
       ]
     }
   }


### PR DESCRIPTION
<!-- AICA Pull Request Template: 10 easy steps for a successful PR!
1. Give the PR a relevant and descriptive title
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
6. Add any supporting resources (screenshots, test results, etc)
7. Help the reviewer by suggestion the method and estimated time to review
8. If applicable, make a checklist of tasks that should be completed before merging
9. If applicable, mention related issues (blocked by / blocks)
10. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->
- https://github.com/aica-technology/dynamic-state-engine/pull/151

<!-- Required: explain how the PR addresses the parent issue -->
This PR adds the controller parameters to the `set` event in the schema. Because neither `controller/interface` nor `component` are required, I had to add basically three different objects that are allowed for the `set`. There might be a simpler version that I didn't see but this works and is tested (with vs code)

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 10 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->