### PR TITLE
refactor(schema): change schema URIs from develop to main

### DIFF
--- a/schemas/component-descriptions/schema/component.schema.json
+++ b/schemas/component-descriptions/schema/component.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/component-descriptions/schema/component.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/component-descriptions/schema/component.schema.json",
   "title": "Dynamic Component Description",
   "description": "A full description of a dynamic component in the AICA application framework.",
   "type": "object",
@@ -63,7 +63,7 @@
       "description": "The fixed input signals (subscriptions) of the component.",
       "type": "array",
       "items": {
-        "$ref": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/signals/schema/signal.schema.json"
+        "$ref": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/signals/schema/signal.schema.json"
       },
       "uniqueItems": true
     },
@@ -81,7 +81,7 @@
       "description": "The output signals (publications) of the component.",
       "type": "array",
       "items": {
-        "$ref": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/signals/schema/signal.schema.json"
+        "$ref": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/signals/schema/signal.schema.json"
       },
       "uniqueItems": true
     },
@@ -90,7 +90,7 @@
       "description": "The parameters declared by the component.",
       "type": "array",
       "items": {
-        "$ref": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/parameters/schema/parameter.schema.json"
+        "$ref": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/parameters/schema/parameter.schema.json"
       },
       "uniqueItems": true
     },

--- a/schemas/component-descriptions/schema/predicate.schema.json
+++ b/schemas/component-descriptions/schema/predicate.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/component-descriptions/schema/predicate.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/component-descriptions/schema/predicate.schema.json",
   "title": "Component Predicate",
   "description": "A predicate signal parameter of a dynamic component.",
   "type": "object",

--- a/schemas/component-descriptions/schema/service.schema.json
+++ b/schemas/component-descriptions/schema/service.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/component-descriptions/schema/service.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/component-descriptions/schema/service.schema.json",
   "title": "Component Service",
   "description": "A service endpoint of a dynamic component.",
   "type": "object",

--- a/schemas/component-descriptions/schema/signal_collection.schema.json
+++ b/schemas/component-descriptions/schema/signal_collection.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/component-descriptions/schema/signal_collection.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/component-descriptions/schema/signal_collection.schema.json",
   "title": "Input Signal Collection",
   "description": "A dynamic collection of input signals that can have zero or more topics of the same type.",
   "type": "object",
@@ -32,13 +32,13 @@
     },
     "signal_type": {
       "description": "The default type of the signals (signals in a collection must have the same type).",
-      "$ref": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/signals/schema/signal_type.schema.json"
+      "$ref": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/signals/schema/signal_type.schema.json"
     },
     "signal_types": {
       "description": "An array of signal types supported by configurable typing. The active type is set through the '<$input_collection_name>_type' parameter, and the default type is determined by the `signal_type` property.",
       "type": "array",
       "items": {
-        "$ref": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/signals/schema/signal_type.schema.json"
+        "$ref": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/signals/schema/signal_type.schema.json"
       },
       "minItems": 1,
       "uniqueItems": true

--- a/schemas/controller-descriptions/schema/controller.schema.json
+++ b/schemas/controller-descriptions/schema/controller.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/controller-descriptions/schema/controller.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/controller-descriptions/schema/controller.schema.json",
   "title": "AICA Controller Description",
   "description": "A full description of a controller in the AICA application framework.",
   "type": "object",
@@ -75,7 +75,7 @@
       "description": "The fixed input signals (subscriptions) of the controller.",
       "type": "array",
       "items": {
-        "$ref": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/signals/schema/signal.schema.json"
+        "$ref": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/signals/schema/signal.schema.json"
       },
       "uniqueItems": true
     },
@@ -84,7 +84,7 @@
       "description": "The output signals (publications) of the controller.",
       "type": "array",
       "items": {
-        "$ref": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/signals/schema/signal.schema.json"
+        "$ref": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/signals/schema/signal.schema.json"
       },
       "uniqueItems": true
     },
@@ -93,7 +93,7 @@
       "description": "The parameters declared by the controller.",
       "type": "array",
       "items": {
-        "$ref": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/parameters/schema/parameter.schema.json"
+        "$ref": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/parameters/schema/parameter.schema.json"
       },
       "uniqueItems": true
     }

--- a/schemas/parameters/schema/encoded_state_type.schema.json
+++ b/schemas/parameters/schema/encoded_state_type.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/parameters/schema/encoded_state_type.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/parameters/schema/encoded_state_type.schema.json",
   "title": "Encoded State Type",
   "description": "The state type of an encoded value from a collection of supported types, as defined in clproto.",
   "type": "string",

--- a/schemas/parameters/schema/parameter.schema.json
+++ b/schemas/parameters/schema/parameter.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/parameters/schema/parameter.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/parameters/schema/parameter.schema.json",
   "title": "Parameter",
   "description": "A dynamic parameter that is publicly configurable.",
   "type": "object",

--- a/schemas/parameters/schema/parameter_type.schema.json
+++ b/schemas/parameters/schema/parameter_type.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/parameters/schema/parameter_type.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/parameters/schema/parameter_type.schema.json",
   "title": "Parameter Type",
   "description": "The value type of a parameter from a collection of supported types.",
   "type": "string",

--- a/schemas/signals/schema/signal.schema.json
+++ b/schemas/signals/schema/signal.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/signals/schema/signal.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/signals/schema/signal.schema.json",
   "title": "Signal",
   "description": "A continuous data signal in the AICA framework that can be an input or an output.",
   "type": "object",

--- a/schemas/signals/schema/signal_type.schema.json
+++ b/schemas/signals/schema/signal_type.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/signals/schema/signal_type.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/signals/schema/signal_type.schema.json",
   "title": "Signal Type",
   "description": "Supported signal value types as simple atomic types or encoded state types.",
   "anyOf": [
@@ -16,7 +16,7 @@
       ]
     },
     {
-      "$ref": "https://raw.githubusercontent.com/aica-technology/api/develop/schemas/parameters/schema/encoded_state_type.schema.json"
+      "$ref": "https://raw.githubusercontent.com/aica-technology/api/main/schemas/parameters/schema/encoded_state_type.schema.json"
     }
   ]
 }


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

A necessary patch before #50. This preemptively changes all of the re

Note; using `main` is a temporary solution. The plan is to tag the repository with a version of the schema and then use that instead of the branch name in the URI. That can be done after everything is on main, and perhaps after the API refactor, so that we can properly version the schemas, the API and the python client. 

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 0 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->