### PR TITLE
fix(docs): base url for docusaurus

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -12,7 +12,7 @@ const config = {
   favicon: "img/favicon.ico",
 
   url,
-  baseUrl: "/",
+  baseUrl: "/api/",
 
   // GitHub pages deployment config.
   organizationName: "aica-technology",


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

I noticed that the GitHub docs pages (https://aica-technology.github.io/api) is not rendering correctly after the merge to main, and https://docs.aica.tech does not resolve to a valid GitHub page at all.

For the first issue, the suggested resolution is to be to fix up the base url. Not sure if that will resolve the second issue @LouisBrunner @jjenscodee ?

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 2 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->