### PR TITLE
fix: use v2 address for endpoints

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -5,6 +5,10 @@ Release Versions:
 - [1.0.1](#101)
 - [1.0.0](#100)
 
+## 1.0.2
+
+Patch the endpoint URL to correctly address API version 2.0
+
 ## 1.0.1
 
 Version 1.0.1 fixes a relative import issue.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aica_api"
-version = "1.0.1"
+version = "1.0.2"
 authors = [
   { name="Enrico Eberhard", email="enrico@aica.tech" },
 ]

--- a/python/src/aica_api/client.py
+++ b/python/src/aica_api/client.py
@@ -36,7 +36,7 @@ class AICA:
         :param endpoint: The API endpoint
         :return: The constructed request address
         """
-        return f'{self._address}/v1/{endpoint}'
+        return f'{self._address}/v2/{endpoint}'
 
     def _ws_endpoint(self, endpoint=''):
         """


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

The API endpoint was still pointing to v1 🤦 

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 0.1 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->