### PR TITLE
feat: support hardware and controller states and predicates in `wait_for_` functions

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -10,6 +10,10 @@ Release Versions:
 - [1.0.1](#101)
 - [1.0.0](#100)
 
+## Upcoming changes
+
+- feat: support hardware and controller states and predicates in `wait_for` functions (#156)
+
 ## 2.0.0
 
 This version of the AICA API client is compatible with the new AICA API server version 3.0 by using Socket.IO instead of


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

- #156 

<!-- Required: explain how the PR addresses the parent issue -->
This PR solves the issue by fixing the return type of the `wait_for_` functions using an explicit `is not None` operator.

It also adds new functions to wait for controller and hardware states and controller predicates. As part of this, the `wait_for_predicate` has been marked as deprecated in favor of the equivalent `wait_for_component_predicate`, in order to to disambiguate component and controller predicates more effectively.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 3 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->