### PR TITLE
feat(client): define more detailed feature and function compatibility between versions

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -13,6 +13,7 @@ Release Versions:
 ## Upcoming changes
 
 - feat: support hardware and controller states and predicates in `wait_for` functions (#156)
+- feat: define more detailed feature and function compatibility between versions (#158)
 
 ## 2.0.0
 

--- a/python/README.md
+++ b/python/README.md
@@ -42,15 +42,21 @@ else:
 
 ## Compatability table
 
-The latest version of the AICA API client will generally support the latest API version in the AICA framework. For
-older versions of the AICA framework, it may be necessary to install older versions of the client. Use the following
-compatability table to determine which client version to use.
+The latest version of the AICA API client will generally support the latest API server version in the AICA framework.
+Major changes to the API client or server versions indicate breaking changes and are not backwards compatible. To
+interact with older versions of the AICA framework, it may be necessary to install older versions of the client.
+Use the following compatability table to determine which client version to use.
 
-| API server version | Matching Python client version |
-|--------------------|--------------------------------|
-| `v3.x`             | `>= v2.0.0`                    |
-| `v2.x`             | `v1.2.0`                       |
-| `<= v1.x`          | Unsupported                    |
+| API server version | Matching Python client version  |
+|--------------------|---------------------------------|
+| `3.x`              | `>= 2.0.0`                      |
+| `2.x`              | `1.2.0`                         |
+| `<= 1.x`           | Unsupported                     |
+
+Between major version changes, minor updates to the API server version and Python client versions may introduce new
+endpoints and functions respectively. If a function requires a feature that the detected API server version does not yet
+support (as is the case when the Python client version is more up-to-date than the targeted API server), then calling
+that function will return None with a warning.
 
 Recent client versions also support the following functions to check the client version and API compatability.
 
@@ -59,9 +65,14 @@ from aica_api.client import AICA
 
 aica = AICA()
 
+# get the current API server version
+print(aica.api_version())
 # get the current client version
-aica.client_version()
+print(aica.client_version())
 
 # check compatability between the client version and API version
-aica.check()
+if aica.check():
+    print('Versions are compatible')
+else:
+    print('Versions are incompatible')
 ```

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aica_api"
-version = "2.0.0"
+version = "2.1.0-rc.1"
 authors = [
   { name="Enrico Eberhard", email="enrico@aica.tech" },
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,8 +12,11 @@ description = "A client utility for the AICA API"
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
-    "requests >= 2.28.1",
-    "python-socketio[client] >= 5.11.0"
+    "deprecation ~= 2.1.0",
+    "python-socketio[client] ~= 5.11.0",
+    "pyyaml ~= 6.0.1",
+    "requests ~= 2.28.1",
+    "semver ~= 3.0.2"
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/python/src/aica_api/client.py
+++ b/python/src/aica_api/client.py
@@ -1,13 +1,19 @@
+from deprecation import deprecated
+from functools import wraps
+from logging import getLogger
 from typing import Union, List
-from warnings import deprecated
 
 import os
 import requests
+import semver
 import yaml
 
 import importlib.metadata
 
 from aica_api.sio_client import read_until
+
+
+CLIENT_VERSION = importlib.metadata.version('aica_api')
 
 
 class AICA:
@@ -33,6 +39,9 @@ class AICA:
         else:
             self._address = f'http://{url}:{port}'
 
+        self._logger = getLogger(__name__)
+        self._api_version = None
+
     def _endpoint(self, endpoint=''):
         """
         Build the request address for a given endpoint.
@@ -43,13 +52,56 @@ class AICA:
         return f'{self._address}/v2/{endpoint}'
 
     @staticmethod
+    def _requires_api_version(version):
+        """
+        Decorator to mark a function with a specific API server version constraint.
+        Elides the function call and returns None with a warning if the version constraint is violated.
+
+        Example usage:
+        @_requires_api_version('>=3.2.1')
+        def my_new_endpoint()
+          ...
+
+        :param version: The version constraint specifier (i.e. >=3.2.1)
+        """
+        def decorator(func):
+            @wraps(func)
+            def wrapper(self, *args, **kwargs):
+                if self._api_version is None and self.api_version() is None:
+                    return None
+                if not semver.match(self._api_version, version):
+                    self._logger.warning(f'The function {func.__name__} requires API server version {version}, '
+                                         f'but the current API server version is {self._api_version}')
+                    return None
+                return func(self, *args, **kwargs)
+
+            return wrapper
+
+        return decorator
+
+    def api_version(self) -> Union[str, None]:
+        """
+        Get the version of the AICA API server
+
+        :return: The version of the API server or None in case of
+        """
+        try:
+            self._api_version = requests.get(f'{self._address}/version').json()
+            self._logger.debug(f'API server version identified as {self._api_version}')
+        except requests.exceptions.RequestException:
+            self._logger.error(f'Error connecting to the API server at {self._address}! '
+                               f'Check that the AICA container is running and configured with the right address.')
+            self._api_version = None
+        return self._api_version
+
+    @staticmethod
     def client_version() -> str:
         """
         Get the version of this API client utility
 
         :return: The version of the API client
         """
-        return importlib.metadata.version('aica_api')
+        return CLIENT_VERSION
 
     def check(self) -> bool:
         """
@@ -57,21 +109,26 @@ class AICA:
 
         :return: True if the client is compatible with the API server version, False otherwise
         """
-        try:
-            api_version = requests.get(f'{self._address}/version').json()
-        except requests.exceptions.RequestException as e:
-            print(f'Error connecting to the API! {e}')
+        if self._api_version is None and self.api_version() is None:
             return False
 
-        if api_version.startswith('3'):
+        version_info = semver.parse_version_info(self._api_version)
+
+        if version_info.major == 3:
             return True
-        elif api_version.startswith('2'):
-            print(f'The detected API version v{api_version} is older than the minimum API version v3.0.0 supported by '
-                  f'this client (v{self.client_version()}). Please install Python API client version v1.2.0 '
-                  f'for API server versions v2.X.')
+        elif version_info.major > 3:
+            self._logger.error(f'The detected API version v{self._api_version} is newer than the maximum API version '
+                               f'supported by this client (v{self.client_version()}). Please upgrade the Python API '
+                               f'client version for newer API server versions.')
+            return False
+        elif version_info.major == 2:
+            self._logger.error(f'The detected API version v{self._api_version} is older than the minimum API version '
+                               f'supported by this client (v{self.client_version()}). Please downgrade the Python API '
+                               f'client to version v1.2.0 for API server versions v2.X.')
             return False
         else:
-            print(f'The detected API version v{api_version} is deprecated and not supported by this API client!')
+            self._logger.error(f'The detected API version v{self._api_version} is deprecated and not supported by '
+                               f'this API client!')
             return False
 
     def component_descriptions(self) -> requests.Response:
@@ -280,6 +337,7 @@ class AICA:
         return read_until(lambda data: data[component]['state'] == state, url=self._address, namespace='/v2/components',
                           event='component_data', timeout=timeout) is not None
 
+    @_requires_api_version('>=3.1.0')
     def wait_for_hardware(self, hardware: str, state: str, timeout: Union[None, int, float] = None) -> bool:
         """
         Wait for a hardware interface to be in a particular state. Hardware can be in any of the following states:
@@ -293,6 +351,7 @@ class AICA:
         return read_until(lambda data: data[hardware]['state'] == state, url=self._address, namespace='/v2/hardware',
                           event='hardware_data', timeout=timeout) is not None
 
+    @_requires_api_version('>=3.1.0')
     def wait_for_controller(self, hardware: str, controller: str, state: str,
                             timeout: Union[None, int, float] = None) -> bool:
         """
@@ -308,7 +367,8 @@ class AICA:
         return read_until(lambda data: data[hardware]['controllers'][controller]['state'] == state, url=self._address,
                           namespace='/v2/hardware', event='hardware_data', timeout=timeout) is not None
 
-    @deprecated("Use wait_for_component_predicate instead")
+    @deprecated(deprecated_in='2.1.0', removed_in='3.0.0', current_version=CLIENT_VERSION,
+                details='Use the wait_for_component_predicate function instead')
     def wait_for_predicate(self, component: str, predicate: str, timeout: Union[None, int, float] = None) -> bool:
         """
         Wait until a component predicate is true.
@@ -321,6 +381,7 @@ class AICA:
         return read_until(lambda data: data[component]['predicates'][predicate], url=self._address,
                           namespace='/v2/components', event='component_data', timeout=timeout) is not None
 
+    @_requires_api_version('>=3.1.0')
     def wait_for_component_predicate(self, component: str, predicate: str,
                                      timeout: Union[None, int, float] = None) -> bool:
         """
@@ -334,6 +395,7 @@ class AICA:
         return read_until(lambda data: data[component]['predicates'][predicate], url=self._address,
                           namespace='/v2/components', event='component_data', timeout=timeout) is not None
 
+    @_requires_api_version('>=3.1.0')
     def wait_for_controller_predicate(self, hardware: str, controller: str, predicate: str,
                                       timeout: Union[None, int, float] = None) -> bool:
         """


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

- #158 

Check feature and function version compatibility more precisely:

* Use deprecation module to warn deprecated function with version range
* Add helper and local class attribute to get and store api server version
* Define decorator to require a minimum api server version when calling a function, otherwise warn and return None
* Update check() function with more cases
* Use semver module to compare and match versions instead of string comparisons
* Use logging module instead of printing warnings
* build: add and revise dependencies

## Supporting information

To test this out properly (since I changed some dependencies), I pushed a release candidate to the test registry at https://test.pypi.org/project/aica-api/2.1.0rc5. As part of this, I learned that doing a pip install from this registry will also try to install all dependencies from the test registry. This will fail against the version checks, since not every package and certainly not every latest version is on the test registry. In this particular case, if you want to test the prebuilt version from the test registry, you need to install or upgrade all dependencies manually first:
```
## first install dependencies manually from the standard pypi registry
python3 -m pip install --upgrade pyyaml deprecation semver python-socketio
## then install the release candidate from the test.pypi registry
python3 -m pip install -i https://test.pypi.org/simple/ aica-api==2.1.0rc5
```
Another option for testing of course is to install locally from this source repo (`pip install .`).

In general, I think it's preferable to make actual release candidate builds for the official registry (using the pre-release specifier `-rc.X`), which would be built and pushed here automatically after merging. Pre-release builds are not listed or installed by default when just using `pip install aica-client`, since it will always use the latest stable version in that case. If we see all behaviors and dependencies work as expected after testing, we can officially release by removing the `-rc.X` specifier and updating the changelog. 

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 15 minutes

I checked it with a AICA `base` images v3.1 and v3.2, which include backend-API server versions v3.0.3 and v3.1.0 respectively. It correctly warned for the unsupported functions (wait for controller, hardware, etc).

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->