### PR TITLE
docs: add -u ros2 to docker exec guide

### DIFF
--- a/docs/docs/getting-started/04-run.md
+++ b/docs/docs/getting-started/04-run.md
@@ -100,8 +100,11 @@ Change `CONTAINER_NAME` in the command below to the name of the running containe
 :::
 
 ```bash
-docker container exec -it CONTAINER_NAME /bin/bash
+docker container exec -it -u ros2 CONTAINER_NAME /bin/bash
 ```
+
+The flags `-it -u ros2` tell docker to attach an interactive terminal as the `ros2` user. The command `/bin/bash`
+starts a shell process.
 
 :::tip
 
@@ -138,7 +141,7 @@ Access control can be re-enabled with `xhost -`.
 
 ```bash
 xhost +
-docker container exec -it -e DISPLAY="$DISPLAY" -e XAUTHORITY="$XAUTH" CONTAINER_NAME /bin/bash
+docker container exec -it -u ros2 -e DISPLAY="$DISPLAY" -e XAUTHORITY="$XAUTH" CONTAINER_NAME /bin/bash
 ```
 
 You should then be able to run `rviz2` inside the container and see the window appear.


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

This is a small bug in the docs that I have been meaning to fix for a while. Simply, I forgot to include the `-u ros2` flag from the docker exec steps for interactive containers. This means things like `ros2 topic list` and `rviz2` would not work exactly as expected. In particular, rviz2 would not see any TFs.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 2 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [NA] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->