### PR TITLE
feat!: move buttons under graph property and include sequence events

### DIFF
--- a/docs/static/schemas/draft/2-0-0/application.d.ts
+++ b/docs/static/schemas/draft/2-0-0/application.d.ts
@@ -195,10 +195,6 @@ export type NodeNamespace = string;
  */
 export type InputTopics = string[];
 /**
- * The human-readable name to display on the button
- */
-export type ButtonDisplayName = string;
-/**
  * The human-readable name to display on the condition
  */
 export type ConditionDisplayName = string;
@@ -372,6 +368,10 @@ export type SequenceStep = Events | DelayStep | CheckConditionStep;
  */
 export type SequenceSteps = SequenceStep[];
 /**
+ * The human-readable name to display on the button
+ */
+export type ButtonDisplayName = string;
+/**
  * The X position of the element on the graph
  */
 export type XPosition = number;
@@ -391,7 +391,6 @@ export interface YAMLApplicationDescription {
     on_start?: OnStart;
     hardware?: HardwareInterfaces;
     components?: Components;
-    buttons?: Buttons;
     conditions?: Conditions;
     sequences?: Sequences;
     graph?: Graph;
@@ -735,36 +734,6 @@ export interface ComponentPredicates {
 }
 
 /**
- * A description of interactive buttons in the application graph
- */
-export interface Buttons {
-    [k: string]: Button;
-}
-
-/**
- * A named interactive button
- *
- * This interface was referenced by `Buttons`'s JSON-Schema definition
- * via the `patternProperty` "^[a-z]([a-z0-9_]?[a-z0-9])*$".
- */
-export interface Button {
-    display_name?: ButtonDisplayName;
-    on_click?: OnClick;
-}
-
-/**
- * Events that are triggered when the button is pressed
- */
-export interface OnClick {
-    load?: Load;
-    unload?: Unload;
-    call_service?: CallService;
-    lifecycle?: LifecycleEvent;
-    switch_controllers?: SwitchControllers;
-    set?: SetParameter;
-}
-
-/**
  * A description of logical conditions used to trigger events in the application
  */
 export interface Conditions {
@@ -901,6 +870,7 @@ export interface BlockingConditionStepWithTimeout {
  * Information for the graphical representation of the application
  */
 export interface Graph {
+    buttons?: Buttons;
     positions?: {
         on_start?: Position;
         stop?: Position;
@@ -920,6 +890,37 @@ export interface Graph {
             [k: string]: Position;
         };
     };
+}
+
+/**
+ * A description of interactive buttons in the application graph
+ */
+export interface Buttons {
+    [k: string]: Button;
+}
+
+/**
+ * A named interactive button
+ *
+ * This interface was referenced by `Buttons`'s JSON-Schema definition
+ * via the `patternProperty` "^[a-z]([a-z0-9_]?[a-z0-9])*$".
+ */
+export interface Button {
+    display_name?: ButtonDisplayName;
+    on_click?: OnClick;
+}
+
+/**
+ * Events that are triggered when the button is pressed
+ */
+export interface OnClick {
+    load?: Load;
+    unload?: Unload;
+    call_service?: CallService;
+    lifecycle?: LifecycleEvent;
+    switch_controllers?: SwitchControllers;
+    set?: SetParameter;
+    sequence?: ManageSequences;
 }
 
 /**

--- a/docs/static/schemas/draft/2-0-0/application.schema.json
+++ b/docs/static/schemas/draft/2-0-0/application.schema.json
@@ -498,54 +498,6 @@
         }
       }
     },
-    "buttons": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "title": "Buttons",
-      "description": "A description of interactive buttons in the application graph",
-      "type": "object",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
-          "title": "Button",
-          "description": "A named interactive button",
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "display_name": {
-              "title": "Button Display Name",
-              "description": "The human-readable name to display on the button",
-              "type": "string"
-            },
-            "on_click": {
-              "title": "On Click",
-              "description": "Events that are triggered when the button is pressed",
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "load": {
-                  "$ref": "#/$defs/events/properties/load"
-                },
-                "unload": {
-                  "$ref": "#/$defs/events/properties/unload"
-                },
-                "call_service": {
-                  "$ref": "#/$defs/events/properties/call_service"
-                },
-                "lifecycle": {
-                  "$ref": "#/$defs/events/properties/lifecycle"
-                },
-                "switch_controllers": {
-                  "$ref": "#/$defs/events/properties/switch_controllers"
-                },
-                "set": {
-                  "$ref": "#/$defs/events/properties/set"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "conditions": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "title": "Conditions",
@@ -973,6 +925,57 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "buttons": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "title": "Buttons",
+          "description": "A description of interactive buttons in the application graph",
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
+              "title": "Button",
+              "description": "A named interactive button",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "display_name": {
+                  "title": "Button Display Name",
+                  "description": "The human-readable name to display on the button",
+                  "type": "string"
+                },
+                "on_click": {
+                  "title": "On Click",
+                  "description": "Events that are triggered when the button is pressed",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "load": {
+                      "$ref": "#/$defs/events/properties/load"
+                    },
+                    "unload": {
+                      "$ref": "#/$defs/events/properties/unload"
+                    },
+                    "call_service": {
+                      "$ref": "#/$defs/events/properties/call_service"
+                    },
+                    "lifecycle": {
+                      "$ref": "#/$defs/events/properties/lifecycle"
+                    },
+                    "switch_controllers": {
+                      "$ref": "#/$defs/events/properties/switch_controllers"
+                    },
+                    "set": {
+                      "$ref": "#/$defs/events/properties/set"
+                    },
+                    "sequence": {
+                      "$ref": "#/$defs/events/properties/sequence"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "positions": {
           "type": "object",
           "additionalProperties": false,

--- a/schemas/applications/CHANGELOG.md
+++ b/schemas/applications/CHANGELOG.md
@@ -21,6 +21,7 @@ Release Versions:
   and additional packages
 - Application metadata can be defined under the top-level `metadata` property including a name, description and tags
 - Any additional user data can be included in an application under the top-level `userdata` property
+- Interactive UI buttons and all position data is now defined under a top-level `graph` property
 - A running application can be stopped with the `application: stop` event from any event source
 - Components, controllers and hardware support dedicated transition events such as `on_load`, `on_activate`
   and `on_error` which behave as event triggers similar to predicates

--- a/schemas/applications/README.md
+++ b/schemas/applications/README.md
@@ -104,6 +104,32 @@ graph:
         y: 500
 ```
 
+#### UI buttons
+
+The `buttons` property was previously a top-level field that defined the behavior of interactive UI elements in the
+application graph. The definition of buttons have now been moved under the new `graph` property, as these elements
+are only used by the application graph.
+
+Before:
+
+```yaml
+buttons:
+  my_button:
+    on_click:
+      load: ...
+```
+
+After:
+
+```yaml
+graph:
+  buttons:
+    my_button:
+      on_click:
+        load: ...
+```
+
+
 #### Events on start
 
 The `on_start` property is now only permitted to load components, load hardware and start sequences. Previously, it was

--- a/schemas/applications/schema/application.schema.json
+++ b/schemas/applications/schema/application.schema.json
@@ -136,9 +136,6 @@
     "components": {
       "$ref": "components.schema.json"
     },
-    "buttons": {
-      "$ref": "buttons.schema.json"
-    },
     "conditions": {
       "$ref": "conditions.schema.json"
     },

--- a/schemas/applications/schema/buttons.schema.json
+++ b/schemas/applications/schema/buttons.schema.json
@@ -39,6 +39,9 @@
             },
             "set": {
               "$ref": "common/events/set.schema.json"
+            },
+            "sequence": {
+              "$ref": "common/events/sequence.schema.json"
             }
           }
         }

--- a/schemas/applications/schema/graph.schema.json
+++ b/schemas/applications/schema/graph.schema.json
@@ -5,6 +5,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "buttons": {
+      "$ref": "buttons.schema.json"
+    },
     "positions": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

The ability to support sequence events by clicking UI buttons was still missing from the draft, as raised by @yrh012. Additionally, after some discussions I decided to move `buttons` property under the new `graph` section of the YAML, since they are pure UI features that have no other impact on the application structure.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 3 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->