### PR TITLE
feat(schema): add frames and graph edge information

### DIFF
--- a/docs/static/schemas/draft/2-0-0/application.d.ts
+++ b/docs/static/schemas/draft/2-0-0/application.d.ts
@@ -368,6 +368,10 @@ export type SequenceStep = Events | DelayStep | CheckConditionStep;
  */
 export type SequenceSteps = SequenceStep[];
 /**
+ * The reference frame that the positive and orientation of the frame is defined relative to
+ */
+export type ReferenceFrame = string;
+/**
  * The human-readable name to display on the button
  */
 export type ButtonDisplayName = string;
@@ -379,6 +383,10 @@ export type XPosition = number;
  * The Y position of the element on the graph
  */
 export type YPosition = number;
+/**
+ * Custom edge path coordinates as x, y pairs
+ */
+export type EdgePath = Position[];
 
 /**
  * An AICA application graph description using YAML syntax.
@@ -393,6 +401,7 @@ export interface YAMLApplicationDescription {
     components?: Components;
     conditions?: Conditions;
     sequences?: Sequences;
+    frames?: Frames;
     graph?: Graph;
 }
 
@@ -867,6 +876,44 @@ export interface BlockingConditionStepWithTimeout {
 }
 
 /**
+ * A description of the static frames available in the application
+ */
+export interface Frames {
+    [k: string]: Frame;
+}
+
+/**
+ * The position and orientation of a static frame in the application
+ *
+ * This interface was referenced by `Frames`'s JSON-Schema definition
+ * via the `patternProperty` "^[a-z]([a-z0-9_]?[a-z0-9])*$".
+ */
+export interface Frame {
+    position: FramePosition;
+    orientation: FrameOrientation;
+    reference_frame?: ReferenceFrame;
+}
+
+/**
+ * The frame position as Cartesian coordinates
+ */
+export interface FramePosition {
+    x: number;
+    y: number;
+    z: number;
+}
+
+/**
+ * The frame orientation in a unit quaternion representation
+ */
+export interface FrameOrientation {
+    w: number;
+    x: number;
+    y: number;
+    z: number;
+}
+
+/**
  * Information for the graphical representation of the application
  */
 export interface Graph {
@@ -890,6 +937,7 @@ export interface Graph {
             [k: string]: Position;
         };
     };
+    edges?: GraphEdges;
 }
 
 /**
@@ -932,4 +980,21 @@ export interface OnClick {
 export interface Position {
     x: XPosition;
     y: YPosition;
+}
+
+/**
+ * A description of edges in the application with additional graphical information
+ */
+export interface GraphEdges {
+    [k: string]: GraphEdge;
+}
+
+/**
+ * Additional graphical information about a specific edge in the application
+ *
+ * This interface was referenced by `GraphEdges`'s JSON-Schema definition
+ * via the `patternProperty` "^[a-z]([a-z0-9_]?[a-z0-9])*$".
+ */
+export interface GraphEdge {
+    path?: EdgePath;
 }

--- a/docs/static/schemas/draft/2-0-0/application.schema.json
+++ b/docs/static/schemas/draft/2-0-0/application.schema.json
@@ -918,6 +918,82 @@
         }
       }
     },
+    "frames": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "title": "Frames",
+      "description": "A description of the static frames available in the application",
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
+          "title": "Frame",
+          "description": "The position and orientation of a static frame in the application",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "position": {
+              "title": "Frame Position",
+              "description": "The frame position as Cartesian coordinates",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "x": {
+                  "type": "number"
+                },
+                "y": {
+                  "type": "number"
+                },
+                "z": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "x",
+                "y",
+                "z"
+              ]
+            },
+            "orientation": {
+              "title": "Frame Orientation",
+              "description": "The frame orientation in a unit quaternion representation",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "w": {
+                  "type": "number"
+                },
+                "x": {
+                  "type": "number"
+                },
+                "y": {
+                  "type": "number"
+                },
+                "z": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "w",
+                "x",
+                "y",
+                "z"
+              ]
+            },
+            "reference_frame": {
+              "title": "Reference Frame",
+              "description": "The reference frame that the positive and orientation of the frame is defined relative to",
+              "type": "string",
+              "default": "world",
+              "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+            }
+          },
+          "required": [
+            "position",
+            "orientation"
+          ]
+        }
+      }
+    },
     "graph": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "title": "Graph",
@@ -1000,6 +1076,30 @@
             },
             "sequences": {
               "$ref": "#/properties/graph/$defs/position_group"
+            }
+          }
+        },
+        "edges": {
+          "title": "Graph Edges",
+          "description": "A description of edges in the application with additional graphical information",
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
+              "title": "Graph Edge",
+              "description": "Additional graphical information about a specific edge in the application",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "path": {
+                  "title": "Edge Path",
+                  "description": "Custom edge path coordinates as x, y pairs",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/properties/graph/$defs/position"
+                  }
+                }
+              }
             }
           }
         }

--- a/schemas/applications/CHANGELOG.md
+++ b/schemas/applications/CHANGELOG.md
@@ -32,7 +32,10 @@ Release Versions:
 - Hardware control rate can be supplemented with a `rate_tolerance` to determine the allowable deviation from the
   intended control rate, and an optional `strict` flag that immediately shuts down the hardware in case of rate
   deviation or other error
+- Static frames can be defined in the application with a position, orientation, name, and reference frame under the new
+  top-level `frames` property
 - Graph positions can be expressed for all elements, including sequences, conditions and a stop application node
+- Edge path information for custom edge routing can be stored under the `edges` sub-property of `graph`
 - Sequences have a property to support automatic looping
 - Sequences, conditions and controllers now support display names
 - The event structures for lifecycle transitions, service calls and setting parameters now always require the target

--- a/schemas/applications/schema/application.schema.json
+++ b/schemas/applications/schema/application.schema.json
@@ -142,6 +142,9 @@
     "sequences": {
       "$ref": "sequences.schema.json"
     },
+    "frames": {
+      "$ref": "frames.schema.json"
+    },
     "graph": {
       "$ref": "graph.schema.json"
     }

--- a/schemas/applications/schema/frames.schema.json
+++ b/schemas/applications/schema/frames.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Frames",
+  "description": "A description of the static frames available in the application",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
+      "title": "Frame",
+      "description": "The position and orientation of a static frame in the application",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "position": {
+          "title": "Frame Position",
+          "description": "The frame position as Cartesian coordinates",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y",
+            "z"
+          ]
+        },
+        "orientation": {
+          "title": "Frame Orientation",
+          "description": "The frame orientation in a unit quaternion representation",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "w": {
+              "type": "number"
+            },
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "w",
+            "x",
+            "y",
+            "z"
+          ]
+        },
+        "reference_frame": {
+          "title": "Reference Frame",
+          "description": "The reference frame that the positive and orientation of the frame is defined relative to",
+          "type": "string",
+          "default": "world",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        }
+      },
+      "required": [
+        "position",
+        "orientation"
+      ]
+    }
+  }
+}

--- a/schemas/applications/schema/graph.schema.json
+++ b/schemas/applications/schema/graph.schema.json
@@ -34,6 +34,24 @@
           "$ref": "#/$defs/position_group"
         }
       }
+    },
+    "edges": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/position"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "$defs": {
@@ -47,13 +65,13 @@
           "title": "X Position",
           "description": "The X position of the element on the graph",
           "type": "number",
-          "multipleOf" : 20
+          "multipleOf": 20
         },
         "y": {
           "title": "Y Position",
           "description": "The Y position of the element on the graph",
           "type": "number",
-          "multipleOf" : 20
+          "multipleOf": 20
         }
       },
       "required": [

--- a/schemas/applications/schema/graph.schema.json
+++ b/schemas/applications/schema/graph.schema.json
@@ -36,14 +36,20 @@
       }
     },
     "edges": {
+      "title": "Graph Edges",
+      "description": "A description of edges in the application with additional graphical information",
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
         "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
+          "title": "Graph Edge",
+          "description": "Additional graphical information about a specific edge in the application",
           "type": "object",
           "additionalProperties": false,
           "properties": {
             "path": {
+              "title": "Edge Path",
+              "description": "Custom edge path coordinates as x, y pairs",
               "type": "array",
               "items": {
                 "$ref": "#/$defs/position"


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

- https://github.com/aica-technology/api/issues/147

As referenced in the original design spec, this adds two (non-breaking) enhancements to the draft schema, after which I would declare it ready to release as version 2-0-0.

### Frames

Frames are quite simple to define:

```yaml
frames:
  target:   # reference frame is "world" by default
    position:
      x: 0.5
      y: 0.0
      z: 1.0
    orientation:
      w: 1.0
      x: 0.0
      y: 0.0
      z: 0.0
  offset:
    reference_frame: target
    position:
      x: 0.5
      y: 0.0
      z: 1.0
    orientation:
      w: 1.0
      x: 0.0
      y: 0.0
      z: 0.0
```


### Edges

The edge path information is stored under `graph: edges: [edge_id]: path`. By including the `path` sub-property, this leaves room for future expansion, for example to customize the position or content of an edge label. In practice it would look like this:

```yaml
graph:
  positions:
    on_start:
      x: -40
      y: -20
    components:
      signal_point_attractor:
        x: 680
        y: 400
    buttons:
      button:
        x: -320
        y: 620
  buttons:
    button:
      on_click:
        set:
          parameter: linear_precision
          value: !!float 1.0
          component: signal_point_attractor
  edges:
    on_start_on_start_load_signal_point_attractor:
      path:
        - x: 360
          y: 20
        - x: 360
          y: 460
  sequence_sequence_event_trigger_0_load_signal_point_attractor:
    path:
        - x: 620
          y: 460
  button_on_click_set_parameter_signal_point_attractor:
    path:
        - x: 180
          y: 640
        - x: 180
          y: 460
```

## Review guidelines

Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->