### PR TITLE
feat: add missing encoded state types from clproto

### DIFF
--- a/schemas/parameters/schema/encoded_state_type.schema.json
+++ b/schemas/parameters/schema/encoded_state_type.schema.json
@@ -15,9 +15,12 @@
     "joint_state",
     "joint_positions",
     "joint_velocities",
+    "joint_accelerations",
     "joint_torques",
     "shape",
     "ellipsoid",
-    "parameter"
+    "parameter",
+    "digital_io_state",
+    "analog_io_state"
   ]
 }


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

I noticed that `joint_accelerations` was missing from the encoded state types in the schema. Along with that, we can also add the new IO states.

Because of the way the parameters and signals subschemas are versioned (or rather, not versioned), this has to be released to main before the component and controller descriptions can be tagged with a new version increment.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 2 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [N/A] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->