### PR TITLE
feat(schema): add custom tf prefix and reference frame options in hardware schema

### DIFF
--- a/schemas/applications/CHANGELOG.md
+++ b/schemas/applications/CHANGELOG.md
@@ -19,6 +19,7 @@ Release Versions:
 
 - feat: add intra process comms field to component schema (#192)
 - feat: add joint positions to application schema (#215)
+- feat: add custom tf_prefix and reference_frame support in schema (#216)
 
 ## 2-0-2
 

--- a/schemas/applications/schema/hardware.schema.json
+++ b/schemas/applications/schema/hardware.schema.json
@@ -27,7 +27,7 @@
           ]
         },
         "tf_prefix": {
-            "description": "The TF prefix to use for the URDF",
+            "description": "An optional TF prefix to apply to all of the links in the URDF to distinguish multiple instances of the same robot",
             "type": "string",
             "default": "",
             "examples": [
@@ -37,9 +37,8 @@
             ]
         },
         "reference_frame": {
-            "description": "The reference frame to use for the URDF",
+            "description": "An optional reference frame to relocate the hardware in the 3D scene. If left empty, the root link in the URDF will be used as the reference frame of the hardware instead.",
             "type": "string",
-            "default": "",
             "examples": [
               "world"
             ]

--- a/schemas/applications/schema/hardware.schema.json
+++ b/schemas/applications/schema/hardware.schema.json
@@ -26,6 +26,24 @@
             250
           ]
         },
+        "tf_prefix": {
+            "description": "The TF prefix to use for the URDF",
+            "type": "string",
+            "default": "",
+            "examples": [
+              "my_robot_",
+              "left_robot_",
+              "robot_1_"
+            ]
+        },
+        "reference_frame": {
+            "description": "The reference frame to use for the URDF",
+            "type": "string",
+            "default": "",
+            "examples": [
+              "world"
+            ]
+        },
         "strict": {
           "title": "Strict Hardware",
           "description": "If true, automatically stop controller execution on error or if the execution rate drops below the rate tolerance threshold",


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

- https://github.com/aica-technology/core-backend/issues/426

<!-- Required: explain how the PR addresses the parent issue -->
This PR solves the issue by adding 2 new options in the hardware section of the schema. This way, we can now define a `tf_prefix` and `reference_frame` that can be internally parsed as part of the hardware.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 2 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->