### PR TITLE
fix(schema): less restrictive frame names

### DIFF
--- a/schemas/applications/schema/frames.schema.json
+++ b/schemas/applications/schema/frames.schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
+    "[a-zA-Z0-9_-]": {
       "title": "Frame",
       "description": "The position and orientation of a static frame in the application",
       "type": "object",
@@ -64,7 +64,7 @@
           "description": "The reference frame that the positive and orientation of the frame is defined relative to",
           "type": "string",
           "default": "world",
-          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+          "pattern": "[a-zA-Z0-9_-]"
         }
       },
       "required": [


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

<!-- Required: explain how the PR addresses the parent issue -->
Working on a demo, we realized that we are being super restrictive with frame names in the YAML. It is for example not possible to publish a frame "test" in reference frame "UR" just because we dont allow capital letters. I quickly checked with TF, it seems that they allow any character in their frame names, I guess we should just allow numbers, letters, underscore and maybe the dash as well. Would release that as 2-0-4.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 3 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->