### PR TITLE
feat(schema): more permissive names for frames and parameters

### DIFF
--- a/schemas/applications/CHANGELOG.md
+++ b/schemas/applications/CHANGELOG.md
@@ -16,6 +16,10 @@ Release Versions:
 - [1-1-0](#1-1-0)
 - [1-0-0](#1-0-0)
 
+## Upcoming changes
+
+- feat: more permissive names for frames and parameters (#260)
+
 ## 2-0-3
 
 This patch adds new optional properties to components, hardware and the top-level application.

--- a/schemas/applications/schema/common/events/set.schema.json
+++ b/schemas/applications/schema/common/events/set.schema.json
@@ -19,7 +19,7 @@
       "title": "Parameter Name",
       "description": "The name of a parameter to set",
       "type": "string",
-      "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+      "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$"
     },
     "value": {
       "title": "New Parameter Value",

--- a/schemas/applications/schema/common/parameters.schema.json
+++ b/schemas/applications/schema/common/parameters.schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
+    "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$": {
       "title": "Parameter Value",
       "description": "The value assigned to the named parameter",
       "type": [

--- a/schemas/applications/schema/frames.schema.json
+++ b/schemas/applications/schema/frames.schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "[a-zA-Z0-9_-]": {
+    "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$": {
       "title": "Frame",
       "description": "The position and orientation of a static frame in the application",
       "type": "object",
@@ -64,7 +64,7 @@
           "description": "The reference frame that the positive and orientation of the frame is defined relative to",
           "type": "string",
           "default": "world",
-          "pattern": "[a-zA-Z0-9_-]"
+          "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$"
         }
       },
       "required": [


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

- #246 

<!-- Required: explain how the PR addresses the parent issue -->
This PR solves the issue by relaxing the pattern properties of for parameter names. Now, numbers and capital letters are allowed anywhere in the name - also at the beginning. Also, there can be dots and dashes apart from the underscore. The same change was applied to frames, PR #235 was not good. It's not a problem since this change was not released yet.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->