### PR TITLE
feat(schema): switch interface descriptions back to arrays

### DIFF
--- a/docs/static/schemas/draft/1-0-0/extension.schema.json
+++ b/docs/static/schemas/draft/1-0-0/extension.schema.json
@@ -24,6 +24,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "assignment_name": {
+          "description": "The assignment name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The human-readable assignment name.",
           "examples": [
@@ -44,6 +49,7 @@
         }
       },
       "required": [
+        "assignment_name",
         "display_name",
         "description",
         "assignment_type"
@@ -102,6 +108,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "parameter_name": {
+          "description": "The parameter name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The human-readable parameter name.",
           "examples": [
@@ -157,6 +168,7 @@
         }
       },
       "required": [
+        "parameter_name",
         "display_name",
         "description",
         "parameter_type",
@@ -235,6 +247,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "predicate_name": {
+          "description": "The predicate name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The human-readable predicate name.",
           "type": "string"
@@ -245,6 +262,7 @@
         }
       },
       "required": [
+        "predicate_name",
         "display_name",
         "description"
       ]
@@ -256,6 +274,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "service_name": {
+          "description": "The service name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The human-readable service name.",
           "type": "string"
@@ -270,11 +293,6 @@
             "string",
             "object"
           ]
-        },
-        "service_name": {
-          "deprecated": true,
-          "description": "The lower_snake_case service name as it is declared in the component or controller. This property is deprecated and services should be mapped by their service name in future usage.",
-          "type": "string"
         },
         "payload_description": {
           "description": "A description of the service payload.",
@@ -298,6 +316,7 @@
         }
       },
       "required": [
+        "service_name",
         "display_name",
         "description",
         "service_type"
@@ -359,6 +378,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "signal_name": {
+          "description": "The signal name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The short name of this signal (to be displayed on the edge of the node in the graph view).",
           "examples": [
@@ -409,6 +433,7 @@
         }
       },
       "required": [
+        "signal_name",
         "display_name",
         "description",
         "signal_type"
@@ -461,11 +486,10 @@
       ]
     },
     "signals": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
-          "$ref": "#/$defs/signal"
-        }
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/signal"
       }
     }
   },
@@ -540,11 +564,10 @@
     "assignments": {
       "title": "Assignments",
       "description": "The assignments declared by the extension.",
-      "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$": {
-          "$ref": "#/$defs/assignment"
-        }
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/assignment"
       }
     },
     "inputs": {
@@ -560,31 +583,28 @@
     "parameters": {
       "title": "Parameters",
       "description": "The parameters declared by the extension.",
-      "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$": {
-          "$ref": "#/$defs/parameter"
-        }
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/parameter"
       }
     },
     "predicates": {
       "title": "Predicates",
       "description": "The predicates provided by the extension.",
-      "type": "object",
-      "patternProperties": {
-        "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
-          "$ref": "#/$defs/predicate"
-        }
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/predicate"
       }
     },
     "services": {
       "title": "Services",
       "description": "The services provided by the extension.",
-      "type": "object",
-      "patternProperties": {
-        "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
-          "$ref": "#/$defs/service"
-        }
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/service"
       }
     },
     "control_type": {

--- a/docs/static/schemas/draft/1-0-0/extension.schema.json
+++ b/docs/static/schemas/draft/1-0-0/extension.schema.json
@@ -27,7 +27,7 @@
         "assignment_name": {
           "description": "The assignment name as it is declared in the implementation",
           "type": "string",
-          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+          "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$"
         },
         "display_name": {
           "description": "The human-readable assignment name.",
@@ -111,7 +111,7 @@
         "parameter_name": {
           "description": "The parameter name as it is declared in the implementation",
           "type": "string",
-          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+          "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$"
         },
         "display_name": {
           "description": "The human-readable parameter name.",

--- a/docs/static/schemas/draft/1-0-0/extension.types.schema.json
+++ b/docs/static/schemas/draft/1-0-0/extension.types.schema.json
@@ -24,6 +24,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "assignment_name": {
+          "description": "The assignment name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The human-readable assignment name.",
           "examples": [
@@ -44,6 +49,7 @@
         }
       },
       "required": [
+        "assignment_name",
         "display_name",
         "description",
         "assignment_type"
@@ -102,6 +108,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "parameter_name": {
+          "description": "The parameter name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The human-readable parameter name.",
           "examples": [
@@ -157,6 +168,7 @@
         }
       },
       "required": [
+        "parameter_name",
         "display_name",
         "description",
         "parameter_type",
@@ -189,6 +201,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "predicate_name": {
+          "description": "The predicate name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The human-readable predicate name.",
           "type": "string"
@@ -199,6 +216,7 @@
         }
       },
       "required": [
+        "predicate_name",
         "display_name",
         "description"
       ]
@@ -210,6 +228,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "service_name": {
+          "description": "The service name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The human-readable service name.",
           "type": "string"
@@ -224,11 +247,6 @@
             "string",
             "object"
           ]
-        },
-        "service_name": {
-          "deprecated": true,
-          "description": "The lower_snake_case service name as it is declared in the component or controller. This property is deprecated and services should be mapped by their service name in future usage.",
-          "type": "string"
         },
         "payload_description": {
           "description": "A description of the service payload.",
@@ -252,6 +270,7 @@
         }
       },
       "required": [
+        "service_name",
         "display_name",
         "description",
         "service_type"
@@ -264,6 +283,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "signal_name": {
+          "description": "The signal name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The short name of this signal (to be displayed on the edge of the node in the graph view).",
           "examples": [
@@ -314,17 +338,17 @@
         }
       },
       "required": [
+        "signal_name",
         "display_name",
         "description",
         "signal_type"
       ]
     },
     "signals": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
-          "$ref": "#/$defs/signal"
-        }
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/signal"
       }
     }
   },
@@ -399,11 +423,10 @@
     "assignments": {
       "title": "Assignments",
       "description": "The assignments declared by the extension.",
-      "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$": {
-          "$ref": "#/$defs/assignment"
-        }
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/assignment"
       }
     },
     "inputs": {
@@ -419,31 +442,28 @@
     "parameters": {
       "title": "Parameters",
       "description": "The parameters declared by the extension.",
-      "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$": {
-          "$ref": "#/$defs/parameter"
-        }
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/parameter"
       }
     },
     "predicates": {
       "title": "Predicates",
       "description": "The predicates provided by the extension.",
-      "type": "object",
-      "patternProperties": {
-        "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
-          "$ref": "#/$defs/predicate"
-        }
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/predicate"
       }
     },
     "services": {
       "title": "Services",
       "description": "The services provided by the extension.",
-      "type": "object",
-      "patternProperties": {
-        "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
-          "$ref": "#/$defs/service"
-        }
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/service"
       }
     },
     "control_type": {

--- a/docs/static/schemas/draft/1-0-0/extension.types.schema.json
+++ b/docs/static/schemas/draft/1-0-0/extension.types.schema.json
@@ -27,7 +27,7 @@
         "assignment_name": {
           "description": "The assignment name as it is declared in the implementation",
           "type": "string",
-          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+          "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$"
         },
         "display_name": {
           "description": "The human-readable assignment name.",
@@ -111,7 +111,7 @@
         "parameter_name": {
           "description": "The parameter name as it is declared in the implementation",
           "type": "string",
-          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+          "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$"
         },
         "display_name": {
           "description": "The human-readable parameter name.",

--- a/docs/static/schemas/draft/2-0-0/interfaces.schema.json
+++ b/docs/static/schemas/draft/2-0-0/interfaces.schema.json
@@ -14,7 +14,7 @@
         "assignment_name": {
           "description": "The assignment name as it is declared in the implementation",
           "type": "string",
-          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+          "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$"
         },
         "display_name": {
           "description": "The human-readable assignment name.",
@@ -98,7 +98,7 @@
         "parameter_name": {
           "description": "The parameter name as it is declared in the implementation",
           "type": "string",
-          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+          "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$"
         },
         "display_name": {
           "description": "The human-readable parameter name.",

--- a/docs/static/schemas/draft/2-0-0/interfaces.schema.json
+++ b/docs/static/schemas/draft/2-0-0/interfaces.schema.json
@@ -11,6 +11,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "assignment_name": {
+          "description": "The assignment name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The human-readable assignment name.",
           "examples": [
@@ -31,6 +36,7 @@
         }
       },
       "required": [
+        "assignment_name",
         "display_name",
         "description",
         "assignment_type"
@@ -89,6 +95,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "parameter_name": {
+          "description": "The parameter name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The human-readable parameter name.",
           "examples": [
@@ -127,6 +138,7 @@
         }
       },
       "required": [
+        "parameter_name",
         "display_name",
         "description",
         "parameter_type",
@@ -226,6 +238,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "predicate_name": {
+          "description": "The predicate name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The human-readable predicate name.",
           "type": "string"
@@ -236,6 +253,7 @@
         }
       },
       "required": [
+        "predicate_name",
         "display_name",
         "description"
       ]
@@ -247,6 +265,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "service_name": {
+          "description": "The service name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The human-readable service name.",
           "type": "string"
@@ -261,11 +284,6 @@
             "string",
             "object"
           ]
-        },
-        "service_name": {
-          "deprecated": true,
-          "description": "The lower_snake_case service name as it is declared in the component or controller. This property is deprecated and services should be mapped by their service name in future usage.",
-          "type": "string"
         },
         "payload_description": {
           "description": "A description of the service payload.",
@@ -289,6 +307,7 @@
         }
       },
       "required": [
+        "service_name",
         "display_name",
         "description",
         "service_type"
@@ -350,6 +369,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "signal_name": {
+          "description": "The signal name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The short name of this signal (to be displayed on the edge of the node in the graph view).",
           "examples": [
@@ -400,6 +424,7 @@
         }
       },
       "required": [
+        "signal_name",
         "display_name",
         "description",
         "signal_type"

--- a/docs/static/schemas/draft/2-0-0/interfaces.types.schema.json
+++ b/docs/static/schemas/draft/2-0-0/interfaces.types.schema.json
@@ -11,6 +11,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "assignment_name": {
+          "description": "The assignment name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The human-readable assignment name.",
           "examples": [
@@ -31,6 +36,7 @@
         }
       },
       "required": [
+        "assignment_name",
         "display_name",
         "description",
         "assignment_type"
@@ -89,6 +95,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "parameter_name": {
+          "description": "The parameter name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The human-readable parameter name.",
           "examples": [
@@ -127,6 +138,7 @@
         }
       },
       "required": [
+        "parameter_name",
         "display_name",
         "description",
         "parameter_type",
@@ -180,6 +192,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "predicate_name": {
+          "description": "The predicate name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The human-readable predicate name.",
           "type": "string"
@@ -190,6 +207,7 @@
         }
       },
       "required": [
+        "predicate_name",
         "display_name",
         "description"
       ]
@@ -201,6 +219,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "service_name": {
+          "description": "The service name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The human-readable service name.",
           "type": "string"
@@ -215,11 +238,6 @@
             "string",
             "object"
           ]
-        },
-        "service_name": {
-          "deprecated": true,
-          "description": "The lower_snake_case service name as it is declared in the component or controller. This property is deprecated and services should be mapped by their service name in future usage.",
-          "type": "string"
         },
         "payload_description": {
           "description": "A description of the service payload.",
@@ -243,6 +261,7 @@
         }
       },
       "required": [
+        "service_name",
         "display_name",
         "description",
         "service_type"
@@ -255,6 +274,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "signal_name": {
+          "description": "The signal name as it is declared in the implementation",
+          "type": "string",
+          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+        },
         "display_name": {
           "description": "The short name of this signal (to be displayed on the edge of the node in the graph view).",
           "examples": [
@@ -305,6 +329,7 @@
         }
       },
       "required": [
+        "signal_name",
         "display_name",
         "description",
         "signal_type"

--- a/docs/static/schemas/draft/2-0-0/interfaces.types.schema.json
+++ b/docs/static/schemas/draft/2-0-0/interfaces.types.schema.json
@@ -14,7 +14,7 @@
         "assignment_name": {
           "description": "The assignment name as it is declared in the implementation",
           "type": "string",
-          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+          "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$"
         },
         "display_name": {
           "description": "The human-readable assignment name.",
@@ -98,7 +98,7 @@
         "parameter_name": {
           "description": "The parameter name as it is declared in the implementation",
           "type": "string",
-          "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+          "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$"
         },
         "display_name": {
           "description": "The human-readable parameter name.",

--- a/schemas/extensions/schema/extension.schema.json
+++ b/schemas/extensions/schema/extension.schema.json
@@ -39,11 +39,10 @@
       "$ref": "https://raw.githubusercontent.com/aica-technology/api/main/docs/static/schemas/draft/2-0-0/interfaces.schema.json#/$defs/signal"
     },
     "signals": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
-          "$ref": "#/$defs/signal"
-        }
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/signal"
       }
     }
   },
@@ -118,11 +117,10 @@
     "assignments": {
       "title": "Assignments",
       "description": "The assignments declared by the extension.",
-      "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$": {
-          "$ref": "#/$defs/assignment"
-        }
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/assignment"
       }
     },
     "inputs": {
@@ -138,31 +136,28 @@
     "parameters": {
       "title": "Parameters",
       "description": "The parameters declared by the extension.",
-      "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$": {
-          "$ref": "#/$defs/parameter"
-        }
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/parameter"
       }
     },
     "predicates": {
       "title": "Predicates",
       "description": "The predicates provided by the extension.",
-      "type": "object",
-      "patternProperties": {
-        "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
-          "$ref": "#/$defs/predicate"
-        }
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/predicate"
       }
     },
     "services": {
       "title": "Services",
       "description": "The services provided by the extension.",
-      "type": "object",
-      "patternProperties": {
-        "^[a-z]([a-z0-9_]?[a-z0-9])*$": {
-          "$ref": "#/$defs/service"
-        }
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/service"
       }
     },
     "control_type": {

--- a/schemas/interfaces/schema/common/assignment.schema.json
+++ b/schemas/interfaces/schema/common/assignment.schema.json
@@ -5,6 +5,11 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "assignment_name": {
+      "description": "The assignment name as it is declared in the implementation",
+      "type": "string",
+      "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+    },
     "display_name": {
       "description": "The human-readable assignment name.",
       "examples": [
@@ -25,6 +30,7 @@
     }
   },
   "required": [
+    "assignment_name",
     "display_name",
     "description",
     "assignment_type"

--- a/schemas/interfaces/schema/common/assignment.schema.json
+++ b/schemas/interfaces/schema/common/assignment.schema.json
@@ -8,7 +8,7 @@
     "assignment_name": {
       "description": "The assignment name as it is declared in the implementation",
       "type": "string",
-      "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+      "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$"
     },
     "display_name": {
       "description": "The human-readable assignment name.",

--- a/schemas/interfaces/schema/common/parameter.schema.json
+++ b/schemas/interfaces/schema/common/parameter.schema.json
@@ -8,7 +8,7 @@
     "parameter_name": {
       "description": "The parameter name as it is declared in the implementation",
       "type": "string",
-      "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+      "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]?[a-zA-Z0-9])*$"
     },
     "display_name": {
       "description": "The human-readable parameter name.",

--- a/schemas/interfaces/schema/common/parameter.schema.json
+++ b/schemas/interfaces/schema/common/parameter.schema.json
@@ -5,6 +5,11 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "parameter_name": {
+      "description": "The parameter name as it is declared in the implementation",
+      "type": "string",
+      "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+    },
     "display_name": {
       "description": "The human-readable parameter name.",
       "examples": [
@@ -43,6 +48,7 @@
     }
   },
   "required": [
+    "parameter_name",
     "display_name",
     "description",
     "parameter_type",

--- a/schemas/interfaces/schema/common/predicate.schema.json
+++ b/schemas/interfaces/schema/common/predicate.schema.json
@@ -5,6 +5,11 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "predicate_name": {
+      "description": "The predicate name as it is declared in the implementation",
+      "type": "string",
+      "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+    },
     "display_name": {
       "description": "The human-readable predicate name.",
       "type": "string"
@@ -15,6 +20,7 @@
     }
   },
   "required": [
+    "predicate_name",
     "display_name",
     "description"
   ]

--- a/schemas/interfaces/schema/common/service.schema.json
+++ b/schemas/interfaces/schema/common/service.schema.json
@@ -5,6 +5,11 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "service_name": {
+      "description": "The service name as it is declared in the implementation",
+      "type": "string",
+      "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+    },
     "display_name": {
       "description": "The human-readable service name.",
       "type": "string"
@@ -19,11 +24,6 @@
         "string",
         "object"
       ]
-    },
-    "service_name": {
-      "deprecated": true,
-      "description": "The lower_snake_case service name as it is declared in the component or controller. This property is deprecated and services should be mapped by their service name in future usage.",
-      "type": "string"
     },
     "payload_description": {
       "description": "A description of the service payload.",
@@ -47,6 +47,7 @@
     }
   },
   "required": [
+    "service_name",
     "display_name",
     "description",
     "service_type"

--- a/schemas/interfaces/schema/common/signal.schema.json
+++ b/schemas/interfaces/schema/common/signal.schema.json
@@ -5,6 +5,11 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "signal_name": {
+      "description": "The signal name as it is declared in the implementation",
+      "type": "string",
+      "pattern": "^[a-z]([a-z0-9_]?[a-z0-9])*$"
+    },
     "display_name": {
       "description": "The short name of this signal (to be displayed on the edge of the node in the graph view).",
       "examples": [
@@ -55,6 +60,7 @@
     }
   },
   "required": [
+    "signal_name",
     "display_name",
     "description",
     "signal_type"


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

- #301
- #261

In #324 as part of #301, I made breaking changes to the interfaces schema to specify interfaces as a map of property names, rather than arrays.

Unfortunately as I wrote in https://github.com/aica-technology/api/issues/301#issuecomment-3264021283, this turns out to be intractable in the implementation, and so arrays end up being generally more convenient. 

This reverts the relevant changes but also adds pattern validation to the interface names (as per #325 in regards to #261)

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [N/A] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->