### PR TITLE
feat(schema): remove default value for signal topic

### DIFF
--- a/docs/static/schemas/draft/1-0-0/extension.schema.json
+++ b/docs/static/schemas/draft/1-0-0/extension.schema.json
@@ -398,7 +398,6 @@
         },
         "default_topic": {
           "description": "The default topic name assigned to this signal. If unspecified, it is assumed to be '~/<$signal_name>'. Setting the parameter '<$signal_name>_topic' will override the default value.",
-          "default": "~/signal_name",
           "type": "string"
         },
         "reconfigurable_topic": {

--- a/docs/static/schemas/draft/1-0-0/extension.types.schema.json
+++ b/docs/static/schemas/draft/1-0-0/extension.types.schema.json
@@ -303,7 +303,6 @@
         },
         "default_topic": {
           "description": "The default topic name assigned to this signal. If unspecified, it is assumed to be '~/<$signal_name>'. Setting the parameter '<$signal_name>_topic' will override the default value.",
-          "default": "~/signal_name",
           "type": "string"
         },
         "reconfigurable_topic": {

--- a/docs/static/schemas/draft/2-0-0/interfaces.schema.json
+++ b/docs/static/schemas/draft/2-0-0/interfaces.schema.json
@@ -389,7 +389,6 @@
         },
         "default_topic": {
           "description": "The default topic name assigned to this signal. If unspecified, it is assumed to be '~/<$signal_name>'. Setting the parameter '<$signal_name>_topic' will override the default value.",
-          "default": "~/signal_name",
           "type": "string"
         },
         "reconfigurable_topic": {

--- a/docs/static/schemas/draft/2-0-0/interfaces.types.schema.json
+++ b/docs/static/schemas/draft/2-0-0/interfaces.types.schema.json
@@ -294,7 +294,6 @@
         },
         "default_topic": {
           "description": "The default topic name assigned to this signal. If unspecified, it is assumed to be '~/<$signal_name>'. Setting the parameter '<$signal_name>_topic' will override the default value.",
-          "default": "~/signal_name",
           "type": "string"
         },
         "reconfigurable_topic": {

--- a/schemas/interfaces/CHANGELOG.md
+++ b/schemas/interfaces/CHANGELOG.md
@@ -20,10 +20,11 @@ The 2-0-0 version of the interfaces schema includes major changes for more consi
 - Forbid `parameter_state_type` when `parameter_type` is not `state`
 - Reduce permitted options in `signal_type` by removing all encoded state types except for `state` and replace `other`
   with `external`
+- Remove the `default_value` annotation for default signal topics
 
 ### Features
 
-- Allow any real value default parameter value can now be any real value type, not just null or string
+- Allow any real value default parameter value, not just null or string
 - Use `signal_state_type` to define the encoded state variant when `signal_type` is `state`
 - More explicit validation rules for optional properties
 - Include `integer` in parameter value type for languages that differentiate between integer and floating point numbers

--- a/schemas/interfaces/schema/common/signal.schema.json
+++ b/schemas/interfaces/schema/common/signal.schema.json
@@ -25,7 +25,6 @@
     },
     "default_topic": {
       "description": "The default topic name assigned to this signal. If unspecified, it is assumed to be '~/<$signal_name>'. Setting the parameter '<$signal_name>_topic' will override the default value.",
-      "default": "~/signal_name",
       "type": "string"
     },
     "reconfigurable_topic": {


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

The `default_topic` for signals is an optional property that specifies which topic should be used if no user-supplied topic is present. If absent, we instead fallback to a topic in the namespace of the node with the name of the signal: for a signal name of `foo` it would then be `~/foo`.

To indicate this behavior, we used the JSON schema default value field to indicate that the default value would be in the form of `~/signal_name`. [According to the spec](https://json-schema.org/understanding-json-schema/reference/annotations), "This value is not used to fill in missing values during the validation process". It's just a hint.

However, some tooling ignores this advice and automatically populates the default value regardless, which leads to all signals having the same literal topic name `"~/signal_name"`.

To avoid this issue and to be safe, I remove the annotation entirely.

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 2 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->