### PR TITLE
fix: aica_api/client.py: fix set_component_parameter type annotation

### DIFF
--- a/python/src/aica_api/client.py
+++ b/python/src/aica_api/client.py
@@ -71,7 +71,7 @@ from aica_api.sio_client import read_until
 CLIENT_VERSION = importlib.metadata.version('aica_api')
 
 T = TypeVar('T')
-ValueParamaterT: TypeAlias = Union[bool, int, float, str,
+ValueParameterT: TypeAlias = Union[bool, int, float, str,
                                    list[bool], list[int], list[float], list[str]] 
 
 
@@ -527,7 +527,7 @@ class AICA:
         self,
         component: str,
         parameter: str,
-        value: ValueParamaterT,
+        value: ValueParameterT,
     ) -> None:
         """
         Set a parameter on a component.
@@ -552,7 +552,7 @@ class AICA:
         hardware: str,
         controller: str,
         parameter: str,
-        value: ValueParamaterT,
+        value: ValueParameterT,
     ) -> None:
         """
         Set a parameter on a controller.


### PR DESCRIPTION
## Description

* **Issue**: `str` can be passed as a parameter's value, but the type checker flags it as a type violation.
* This PR addresses this by adding `str` to the union of the accepted types.
* Deduplication of the code for `set_controller_parameter`
* Switching to built-in type aliases (`List` -> `list`)

## Review guidelines

Estimated Time of Review: 10 minutes
Review by commit.